### PR TITLE
Appdata related changes

### DIFF
--- a/data/io.github.dyegoaurelio.simple-wireplumber-gui.appdata.xml.in
+++ b/data/io.github.dyegoaurelio.simple-wireplumber-gui.appdata.xml.in
@@ -12,7 +12,7 @@
 	</screenshots>
 	<releases>
 		<release version="0.1.4" date="2023-10-01">
-			<description translatable="no">
+			<description translate="no">
 				<p>Adding Turkish translation</p>
 			</description>
 		</release>
@@ -20,7 +20,7 @@
 		<release version="0.1.2-fix" date="2023-09-16"/>
 		<release version="0.1.1" date="2023-09-09"/>
 		<release version="0.1" date="2023-09-08">
-			<description translatable="no">
+			<description translate="no">
 				<p>Initial pre-release</p>
 			</description>
 		</release>

--- a/data/io.github.dyegoaurelio.simple-wireplumber-gui.appdata.xml.in
+++ b/data/io.github.dyegoaurelio.simple-wireplumber-gui.appdata.xml.in
@@ -3,6 +3,9 @@
 	<name>Simple Wireplumber GUI</name>
 	<id>io.github.dyegoaurelio.simple-wireplumber-gui.desktop</id>
 	<developer_name>Dyego Aurélio</developer_name>
+	<developer id="io.github.dyegoaurelio">
+		<name>Dyego Aurélio</name>
+	</developer>
 	<screenshots>
 		<screenshot type="default">
 			<image>

--- a/data/io.github.dyegoaurelio.simple-wireplumber-gui.appdata.xml.in
+++ b/data/io.github.dyegoaurelio.simple-wireplumber-gui.appdata.xml.in
@@ -33,6 +33,8 @@
 
 	<url type="homepage">https://github.com/dyegoaurelio/simple-wireplumber-gui</url>
 	<url type="bugtracker">https://github.com/dyegoaurelio/simple-wireplumber-gui/issues</url>
+	<url type="vcs-browser">https://github.com/dyegoaurelio/simple-wireplumber-gui</url>
+	<url type="translate">https://github.com/dyegoaurelio/simple-wireplumber-gui/tree/main/po</url>
 
 	<summary>
 		A simple GTK4 GUI for PipeWire


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer

### appdata: Add vcs-browser and translate URLs

Add vcs-browser and translate URLs to show source code and translation repositories.