### PR TITLE
Fix permission for .config/wireplumber

### DIFF
--- a/io.github.dyegoaurelio.simple-wireplumber-gui.json
+++ b/io.github.dyegoaurelio.simple-wireplumber-gui.json
@@ -10,7 +10,7 @@
         "--device=dri",
         "--share=ipc",
         "--filesystem=xdg-run/pipewire-0",
-        "--filesystem=~/.config/wireplumber/"
+        "--filesystem=xdg-config/wireplumber/:create"
     ],
     "cleanup" : [
         "/include",


### PR DESCRIPTION
This (a) uses `xdg-config` instead of hardcoding `~/.config`, and (b) provides the `:create` permission, so that the WirePlumber config directory can be created if it doesn't exist.

Fixes: https://github.com/dyegoaurelio/simple-wireplumber-gui/issues/20