### PR TITLE
py_mod.find_installation: do not hardcode exe name

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,7 @@ gnome.compile_resources('simple-wireplumber-gui',
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation().path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)


### PR DESCRIPTION
Hypothesis: this way the python module is more likely to correctly locate the python installation across platforms, especially when BUILD!=HOST and, so, the python interpreter isn't in the PATH

Examples of related issues:
- https://github.com/mesonbuild/meson/issues/7415
- https://github.com/open-source-parsers/jsoncpp/pull/1185